### PR TITLE
Documentation extend file locations

### DIFF
--- a/docs/file_locations.md
+++ b/docs/file_locations.md
@@ -20,7 +20,9 @@ Deployment artifact:
 `%APPDATA%\<VendorName>\<ProductName>\`
 
 `bundles`-folder, lock-files and `timestamps.json`:  
-`%LOCALAPPDATA%\<VendorName>\<ProductName>\`
+`%LOCALAPPDATA%\<VendorName>\<ProductName>\`  
+If trivrost is started with the [`--roaming` parameter](cmdline.md#trivrost), the path changes to:
+`%APPDATA%\<VendorName>\<ProductName>\`
 
 Desktop shortcut:  
 `%USERPROFILE%\Desktop\`
@@ -30,7 +32,9 @@ Start menu shortcuts:
 `%APPDATA%\Microsoft\Windows\Start Menu\<VendorName>\Uninstall\`
 
 Log-files:  
-`%LOCALAPPDATA%\Temp\<VendorName>\<ProductName>\log\`
+`%LOCALAPPDATA%\Temp\<VendorName>\<ProductName>\log\`  
+If trivrost is started with the [`--roaming` parameter](cmdline.md#trivrost), the path changes to:
+`%APPDATA%\Temp\<VendorName>\<ProductName>\log\`
 
 ### System mode
 As **Default**, but with the following changes/additions.


### PR DESCRIPTION
Add a hint on the `--roaming` parameter in the documentation on the file locations.