### PR TITLE
Show version of go runtime in logs

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -129,7 +129,7 @@ func processFlags(args []string) (launcherFlags *flags.LauncherFlags, err error)
 }
 
 func logState(argumentError, flagError, pathError, evalError error) {
-	log.Infof("Git commit of this build: Tag: %s; Hash: %s; Branch: %s", gitDescription, gitHash, gitBranch)
+	log.Infof("Git description of this build: %s; Commit hash: %s; Branch: %s; Built with %v", gitDescription, gitHash, gitBranch, runtime.Version())
 
 	if filepath.Base(system.GetProgramPath()) != resources.LauncherConfig.BinaryName {
 		log.Warnf("Program name on disk (\"%s\") has diverged from configured program name (\"%s\").",


### PR DESCRIPTION
With v1.3.4 we fixed a bug which _might_ be a regression issue in the Go runtime. Make sure to log the Go version with which the project was built to make reproducing problems easier.