### PR TITLE
Display guessed hashing progress

### DIFF
--- a/cmd/launcher/launcher/progress_faker.go
+++ b/cmd/launcher/launcher/progress_faker.go
@@ -1,0 +1,25 @@
+package launcher
+
+import (
+	"math"
+	"time"
+)
+
+type progressFaker struct {
+	progressStartTime time.Time
+	progressRate      float64
+}
+
+func newProgressFaker(progressRate float64) *progressFaker {
+	return &progressFaker{progressRate: progressRate}
+}
+
+func (pf *progressFaker) getProgress() uint64 {
+	t := time.Time{}
+	if pf.progressStartTime == t {
+		pf.progressStartTime = time.Now()
+		return 0
+	}
+	diff := time.Since(pf.progressStartTime)
+	return uint64(math.Round(diff.Seconds() * pf.progressRate))
+}

--- a/cmd/launcher/launcher/run.go
+++ b/cmd/launcher/launcher/run.go
@@ -27,9 +27,14 @@ func Run(ctx context.Context, launcherFlags *flags.LauncherFlags) {
 		handleStatusChange(status, expectedProgressUnits)
 	})
 
+	hashLauncherProgress, hashBundlesProgress := newProgressFaker(10), newProgressFaker(10)
 	gui.ProgressFunc = func(s gui.Stage) uint64 {
 		if s.IsDownloadStage() {
 			return handler.GetProgress()
+		} else if s == gui.StageDetermineLocalLauncherVersion {
+			return hashLauncherProgress.getProgress()
+		} else if s == gui.StageDetermineLocalBundleVersions {
+			return hashBundlesProgress.getProgress()
 		}
 		return 0
 	}

--- a/pkg/launcher/bundle/update_bundle.go
+++ b/pkg/launcher/bundle/update_bundle.go
@@ -38,7 +38,7 @@ func (u *Updater) InstallBundleUpdates() {
 }
 
 func (u *Updater) determineLocalBundleVersions() {
-	u.announceStatus(DetermineLocalBundleVersions, 0)
+	u.announceStatus(DetermineLocalBundleVersions, 200)
 	for _, bundleConfig := range u.deploymentConfig.Bundles {
 		var bundleUpdateInfo *BundleUpdateInfo
 		if u.haveSystemBundleWithName(bundleConfig.LocalDirectory) {

--- a/pkg/launcher/bundle/update_self.go
+++ b/pkg/launcher/bundle/update_self.go
@@ -28,7 +28,7 @@ func (u *Updater) UpdateSelf() (needsRestart bool) {
 
 func (u *Updater) updateProgram(programPath string) (needsRestart bool) {
 	log.Infof("Calculating local hashes.")
-	u.announceStatus(DetermineLocalLauncherVersion, 0)
+	u.announceStatus(DetermineLocalLauncherVersion, 20)
 	presentState := hashing.MustHash(u.ctx, programPath)
 
 	log.Infof("Checking against latest version.")


### PR DESCRIPTION
Push progress forward linearly over time for the duration of 2 seconds for hashing of launcher binary and 20 seconds for hashing of bundles.