### PR TITLE
Ignore MacOS `psn` commandline argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release-Changelog
 
+## 1.3.5 (TBD)
+### Fixes
+* Ignore `--psn_X_YYYYY` arugment which is appended by MacOS to the command line arguments when the programm was launched through a Gatekeeper context. Regression found in v1.3.2, v1.3.3, v1.3.4.
+
 ## 1.3.4 (2019-10-29)
 ### Fixes
 * Fix failure to launch on Windows if trivrost binary is located on a mounted volume for which no unique path exists because it has no drive letter assigned. See [this Go issue](https://github.com/golang/go/issues/20506#issuecomment-318514515) for details.

--- a/cmd/launcher/flags/flags.go
+++ b/cmd/launcher/flags/flags.go
@@ -51,6 +51,7 @@ func Setup(args []string) (*LauncherFlags, error) {
 	for i, arg := range args {
 		if (ignoredArgsExp.MatchString(arg)) {
 			args = append(args[:i], args[i+1:]...)
+			break
 		}
 	}
 	flagSet := flag.NewFlagSet(args[0], flag.ContinueOnError)

--- a/cmd/launcher/flags/flags.go
+++ b/cmd/launcher/flags/flags.go
@@ -5,6 +5,7 @@ package flags
 import (
 	"flag"
 	"fmt"
+	"regexp"
 	"strconv"
 )
 
@@ -44,6 +45,14 @@ const (
 
 func Setup(args []string) (*LauncherFlags, error) {
 	launcherFlags := LauncherFlags{nextLogIndex: -1}
+
+	// MacOS might append program serial number which we have to ignore/remove from args
+	ignoredArgsExp, _ := regexp.Compile("-+psn.*")
+	for i, arg := range args {
+		if (ignoredArgsExp.MatchString(arg)) {
+			args = append(args[:i], args[i+1:]...)
+		}
+	}
 	flagSet := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	flagSet.BoolVar(&launcherFlags.Uninstall, UninstallFlag, false, "Remove the launcher and its bundles from the local machine.")
 	flagSet.BoolVar(&launcherFlags.Debug, DebugFlag, false, "Write verbose information to the log files.")


### PR DESCRIPTION
MacOS adds a socalled program serial number when the application was launched
through a GUI like Gatekeeper. Since v1.3.2 we raise an error for unkown
arguments. This patch removes such parameter before parsing the rest.

Fixes #90