### PR TITLE
Log progress on connection errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 1.4.5 (TBD)
 ### Changes
 * Shorter log-output for proxy detection. Reduces size of the log output by 5–15%.
+* trivrost will log the progress of downloads if the connection was interrupted for any reason.
 * Update most dependencies:
   * gopsutils: v2.19.4 -> v2.20.3
   * testify: v1.4.0 -> v1.5.1

--- a/cmd/bundown/main.go
+++ b/cmd/bundown/main.go
@@ -49,7 +49,7 @@ func downloadBundles(deploymentConfig *config.DeploymentConfig, outDirPath strin
 	if err != nil {
 		fatalf("%v", err)
 	}
-	updater := bundle.NewUpdaterWithDeploymentConfig(context.Background(), deploymentConfig, &fetching.ConsoleDownloadPogressHandler{}, resources.PublicRsaKeys)
+	updater := bundle.NewUpdaterWithDeploymentConfig(context.Background(), deploymentConfig, &fetching.ConsoleDownloadProgressHandler{}, resources.PublicRsaKeys)
 	for _, bundle := range deploymentConfig.Bundles {
 		if shouldDownloadBundle(bundle.Tags, tags) {
 			log.Infof("Starting download of bundle %s", bundle.BaseURL)

--- a/cmd/launcher/gui/gui_progress_handler.go
+++ b/cmd/launcher/gui/gui_progress_handler.go
@@ -83,8 +83,8 @@ func (handler *GuiDownloadProgressHandler) HandleBadHttpResponse(fromURL string,
 	NotifyProblem(fmt.Sprintf("HTTP Status %d", code), false)
 }
 
-func (handler *GuiDownloadProgressHandler) HandleReadError(fromURL string, err error) {
-	log.Warnf("GET %s interrupted: %v.", fromURL, err)
+func (handler *GuiDownloadProgressHandler) HandleReadError(fromURL string, err error, firstByteIndex int64) {
+	log.Warnf("GET %s interrupted: %v. Continuing from byte %d", fromURL, err, firstByteIndex)
 	handler.progressMutex.Lock()
 	defer handler.progressMutex.Unlock()
 	handler.problemUrl = fromURL

--- a/cmd/launcher/gui/gui_progress_handler.go
+++ b/cmd/launcher/gui/gui_progress_handler.go
@@ -83,8 +83,8 @@ func (handler *GuiDownloadProgressHandler) HandleBadHttpResponse(fromURL string,
 	NotifyProblem(fmt.Sprintf("HTTP Status %d", code), false)
 }
 
-func (handler *GuiDownloadProgressHandler) HandleReadError(fromURL string, err error, firstByteIndex int64) {
-	log.Warnf("GET %s interrupted: %v. Continuing from byte %d", fromURL, err, firstByteIndex)
+func (handler *GuiDownloadProgressHandler) HandleReadError(fromURL string, err error, receivedByteCount int64) {
+	log.Warnf("GET %s interrupted after receiving %d bytes: %v.", fromURL, receivedByteCount, err)
 	handler.progressMutex.Lock()
 	defer handler.progressMutex.Unlock()
 	handler.problemUrl = fromURL

--- a/pkg/fetching/download.go
+++ b/pkg/fetching/download.go
@@ -204,7 +204,7 @@ func (dl *Download) readFromResponse(p []byte) (n int, err error) {
 		dl.cleanUp() // Note: https://github.com/golang/go/issues/26095#issuecomment-400903313
 		dl.response = nil
 		if err != io.EOF { // Network failures are temporary. Keep trying until it works.
-			dl.handler.HandleReadError(dl.url, err)
+			dl.handler.HandleReadError(dl.url, err, dl.firstByteIndex)
 			return n, nil
 		}
 		if (dl.lastByteIndex >= 0) && (dl.firstByteIndex < dl.lastByteIndex+1) {

--- a/pkg/fetching/downloader_test.go
+++ b/pkg/fetching/downloader_test.go
@@ -39,7 +39,7 @@ func (handler *ErrorRecordingHandler) HandleBadHttpResponse(fromURL string, code
 	handler.ErrChan <- fmt.Errorf("HTTP %d: %s", code, http.StatusText(code))
 }
 
-func (handler *ErrorRecordingHandler) HandleReadError(fromURL string, err error) {
+func (handler *ErrorRecordingHandler) HandleReadError(fromURL string, err error, firstByteIndex int64) {
 	handler.ErrChan <- err
 }
 

--- a/pkg/fetching/downloader_test.go
+++ b/pkg/fetching/downloader_test.go
@@ -39,7 +39,7 @@ func (handler *ErrorRecordingHandler) HandleBadHttpResponse(fromURL string, code
 	handler.ErrChan <- fmt.Errorf("HTTP %d: %s", code, http.StatusText(code))
 }
 
-func (handler *ErrorRecordingHandler) HandleReadError(fromURL string, err error, firstByteIndex int64) {
+func (handler *ErrorRecordingHandler) HandleReadError(fromURL string, err error, receivedByteCount int64) {
 	handler.ErrChan <- err
 }
 

--- a/pkg/fetching/handler.go
+++ b/pkg/fetching/handler.go
@@ -18,36 +18,36 @@ type DownloadProgressHandler interface {
 
 	HandleHttpGetError(fromURL string, err error)   // The HTTP GET request to download the resource did not receive an HTTP response.
 	HandleBadHttpResponse(fromURL string, code int) // A bad HTTP response code was received.
-	HandleReadError(fromURL string, err error)      // An error occurred while reading the response body (data) of the resource at the given URL.
+	HandleReadError(fromURL string, err error, firstByteIndex int64)      // An error occurred while reading the response body (data) of the resource at the given URL.
 }
 
-type ConsoleDownloadPogressHandler struct {
+type ConsoleDownloadProgressHandler struct {
 }
 
-func (handler *ConsoleDownloadPogressHandler) HandleProgress(fromURL string, workerId int, receivedBytes uint64) {
+func (handler *ConsoleDownloadProgressHandler) HandleProgress(fromURL string, workerId int, receivedBytes uint64) {
 }
 
-func (handler *ConsoleDownloadPogressHandler) HandleStartDownload(fromURL string, workerId int) {
+func (handler *ConsoleDownloadProgressHandler) HandleStartDownload(fromURL string, workerId int) {
 	log.Infof("Downloading %s", fromURL)
 }
 
-func (handler *ConsoleDownloadPogressHandler) HandleFinishDownload(fromURL string, workerId int) {
+func (handler *ConsoleDownloadProgressHandler) HandleFinishDownload(fromURL string, workerId int) {
 }
 
-func (handler *ConsoleDownloadPogressHandler) HandleFailDownload(fromURL string, workerId int, err error) {
+func (handler *ConsoleDownloadProgressHandler) HandleFailDownload(fromURL string, workerId int, err error) {
 }
 
-func (handler *ConsoleDownloadPogressHandler) HandleHttpGetError(fromURL string, err error) {
+func (handler *ConsoleDownloadProgressHandler) HandleHttpGetError(fromURL string, err error) {
 	log.Errorf("Error downloading %s: %v.", fromURL, err)
 	os.Exit(1)
 }
 
-func (handler *ConsoleDownloadPogressHandler) HandleBadHttpResponse(fromURL string, code int) {
+func (handler *ConsoleDownloadProgressHandler) HandleBadHttpResponse(fromURL string, code int) {
 	log.Errorf("GET %s yielded bad HTTP response: %v (Code was %d)", fromURL, http.StatusText(code), code)
 	os.Exit(1)
 }
 
-func (handler *ConsoleDownloadPogressHandler) HandleReadError(fromURL string, err error) {
+func (handler *ConsoleDownloadProgressHandler) HandleReadError(fromURL string, err error, firstByteIndex int64) {
 	log.Errorf("Could not copy bytes from \"%s\": %v", fromURL, err)
 	os.Exit(1)
 }
@@ -73,5 +73,5 @@ func (handler *EmptyHandler) HandleHttpGetError(fromURL string, err error) {
 func (handler *EmptyHandler) HandleBadHttpResponse(fromURL string, code int) {
 }
 
-func (handler *EmptyHandler) HandleReadError(fromURL string, err error) {
+func (handler *EmptyHandler) HandleReadError(fromURL string, err error, firstByteIndex int64) {
 }

--- a/pkg/fetching/handler.go
+++ b/pkg/fetching/handler.go
@@ -47,8 +47,8 @@ func (handler *ConsoleDownloadProgressHandler) HandleBadHttpResponse(fromURL str
 	os.Exit(1)
 }
 
-func (handler *ConsoleDownloadProgressHandler) HandleReadError(fromURL string, err error, firstByteIndex int64) {
-	log.Errorf("Could not copy bytes from \"%s\": %v", fromURL, err)
+func (handler *ConsoleDownloadProgressHandler) HandleReadError(fromURL string, err error, receivedByteCount int64) {
+	log.Errorf("Could not copy bytes from \"%s\" (failed after %d bytes): %v", fromURL, receivedByteCount, err)
 	os.Exit(1)
 }
 
@@ -73,5 +73,5 @@ func (handler *EmptyHandler) HandleHttpGetError(fromURL string, err error) {
 func (handler *EmptyHandler) HandleBadHttpResponse(fromURL string, code int) {
 }
 
-func (handler *EmptyHandler) HandleReadError(fromURL string, err error, firstByteIndex int64) {
+func (handler *EmptyHandler) HandleReadError(fromURL string, err error, receivedByteCount int64) {
 }


### PR DESCRIPTION
Sometimes it helps to see in the log if there was any progress at all if the connection drops out.

This patch shows the transferred bytes.