### PR TITLE
Shorten log-output for proxy detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release-Changelog
 
+## 1.4.5 (TBD)
+### Changes
+* Shorter log-output for proxy detection. Reduces size of the log output by 5–15%.
+
 ## 1.4.4 (2020-01-17)
 ### Changes
 * Validator's `/validate` endpoint now always answers with status code 200 OK. Endpoint `/metrics` should be tested for value of `trivrost_validation_ok` as a healthcheck instead.

--- a/pkg/fetching/helpers.go
+++ b/pkg/fetching/helpers.go
@@ -40,7 +40,11 @@ func GetProxyLoggingFunc() func(req *http.Request) (*url.URL, error) {
 		if err != nil {
 			log.Warnf("Getting proxy for URL %v failed: %v", req.URL, err)
 		} else {
-			log.Infof("Proxy for request with URL %v determined proxy URL %v.", req.URL, proxyURL)
+			if proxyURL == nil {
+				log.Infof("GET %v (direct).", req.URL)
+			} else {
+				log.Infof("GET %v (with proxy: %v).", req.URL, proxyURL)
+			}
 		}
 		return proxyURL, err
 	}

--- a/pkg/misc/strings.go
+++ b/pkg/misc/strings.go
@@ -10,7 +10,7 @@ import (
 	"log"
 )
 
-const Ellipsis = "…"
+const ellipsis = "…"
 
 // WordWrap performs word-wrapping on space-separated words within text, keeping existing newline
 // characters intact. Any words which exceed lineWidth in length will move to a new line, but words
@@ -57,12 +57,12 @@ func isBreakingSpace(r rune) bool {
 }
 
 func ShortString(s string, leadingCount int, trailingCount int) string {
-	maxLen := leadingCount + trailingCount + utf8.RuneCountInString(Ellipsis)
+	maxLen := leadingCount + trailingCount + utf8.RuneCountInString(ellipsis)
 	runeCount := utf8.RuneCountInString(s)
 	if runeCount > maxLen {
 		firstByteIndex := RuneIndexToByteIndex(s, leadingCount)
 		omitByteIndex := RuneIndexToByteIndex(s, runeCount-trailingCount)
-		s = s[:firstByteIndex] + Ellipsis + s[omitByteIndex:]
+		s = s[:firstByteIndex] + ellipsis + s[omitByteIndex:]
 	}
 	return s
 }

--- a/pkg/misc/strings.go
+++ b/pkg/misc/strings.go
@@ -10,6 +10,8 @@ import (
 	"log"
 )
 
+const Ellipsis = "…"
+
 // WordWrap performs word-wrapping on space-separated words within text, keeping existing newline
 // characters intact. Any words which exceed lineWidth in length will move to a new line, but words
 // themself will never be split.
@@ -55,13 +57,12 @@ func isBreakingSpace(r rune) bool {
 }
 
 func ShortString(s string, leadingCount int, trailingCount int) string {
-	ellipsis := "..."
-	maxLen := leadingCount + trailingCount + utf8.RuneCountInString(ellipsis)
+	maxLen := leadingCount + trailingCount + utf8.RuneCountInString(Ellipsis)
 	runeCount := utf8.RuneCountInString(s)
 	if runeCount > maxLen {
 		firstByteIndex := RuneIndexToByteIndex(s, leadingCount)
 		omitByteIndex := RuneIndexToByteIndex(s, runeCount-trailingCount)
-		s = s[:firstByteIndex] + ellipsis + s[omitByteIndex:]
+		s = s[:firstByteIndex] + Ellipsis + s[omitByteIndex:]
 	}
 	return s
 }


### PR DESCRIPTION
Reduces size of the log output by 5–15%.