### PR TITLE
Update preallocation dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 1.4.5 (TBD)
 ### Changes
 * Shorter log-output for proxy detection. Reduces size of the log output by 5–15%.
+* No longer preallocate files before downloading (code was unmaintained)
 
 ## 1.4.4 (2020-01-17)
 ### Changes

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/setlog/trivrost
 
 require (
-	git.sr.ht/~tslocum/preallocate v0.1.2
 	github.com/MMulthaupt/chronometry v0.1.1
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
 	github.com/andlabs/ui v0.0.0-20180902183112-867a9e5a498d
@@ -17,6 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.3.0
 	github.com/shirou/gopsutil v0.0.0-20190427031343-fa9845945e5b
 	github.com/sirupsen/logrus v1.4.2
+	github.com/smallnest/preallocate v0.1.1
 	github.com/stretchr/testify v1.4.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
@@ -27,3 +27,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/smallnest/preallocate => git.sr.ht/~tslocum/preallocate v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
-git.sr.ht/~tslocum/preallocate v0.1.2 h1:v17Ctvip7VaqMk63RCjtDb6gq9YdNfWfIBbvcDoziwc=
+git.sr.ht/~tslocum/preallocate v0.1.1 h1:IVdAV4DWNps0SdiDIY/4SoWAnyU4A+xHs13lijqoyXg=
+git.sr.ht/~tslocum/preallocate v0.1.1/go.mod h1:9yyz7jeM3zMwFJ0o6Njpu3K9KeXnWeyzCTbxW6UeXzQ=
 git.sr.ht/~tslocum/preallocate v0.1.2/go.mod h1:9yyz7jeM3zMwFJ0o6Njpu3K9KeXnWeyzCTbxW6UeXzQ=
 github.com/MMulthaupt/chronometry v0.1.1 h1:7z/2ORMk42/k1pEdBG2LIrNWcKjdqXabljsgmKUCLHA=
 github.com/MMulthaupt/chronometry v0.1.1/go.mod h1:sp7LDX9NJVTqiR84IGVlzHhAJoS/kByMVy77Es08ciI=

--- a/pkg/fetching/downloader.go
+++ b/pkg/fetching/downloader.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"git.sr.ht/~tslocum/preallocate"
+	"github.com/smallnest/preallocate"
 	"github.com/setlog/trivrost/pkg/misc"
 	"github.com/setlog/trivrost/pkg/signatures"
 


### PR DESCRIPTION
The dependency used for preallocating is no longer maintained, giving 404s.
One fork on github exists, but with an incorrect module path. The missing
dependency caused other issues, thus this commit removes the function and
dependency