### PR TITLE
Shorten logged HTTP errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## 1.4.5 (TBD)
 ### Changes
-* Shorter log-output for proxy detection. Reduces size of the log output by 5–15%.
+* Shorter log-output for proxy detection. Reduces average size of the log output by 5–15%.
+* Shorter log-output for HTTP errors, reduces size of log output by a few percent.
 * trivrost will log the progress of downloads if the connection was interrupted for any reason.
 * Update most dependencies:
   * gopsutils: v2.19.4 -> v2.20.3

--- a/cmd/launcher/gui/gui_progress_handler.go
+++ b/cmd/launcher/gui/gui_progress_handler.go
@@ -76,7 +76,7 @@ func (handler *GuiDownloadProgressHandler) HandleHttpGetError(fromURL string, er
 }
 
 func (handler *GuiDownloadProgressHandler) HandleBadHttpResponse(fromURL string, code int) {
-	log.Warnf("GET %s yielded bad HTTP response: %s (Code was %d)", fromURL, http.StatusText(code), code)
+	log.Warnf("GET %s, error %d: %s", fromURL, code, http.StatusText(code))
 	handler.progressMutex.Lock()
 	defer handler.progressMutex.Unlock()
 	handler.problemUrl = fromURL

--- a/pkg/fetching/handler.go
+++ b/pkg/fetching/handler.go
@@ -43,7 +43,7 @@ func (handler *ConsoleDownloadProgressHandler) HandleHttpGetError(fromURL string
 }
 
 func (handler *ConsoleDownloadProgressHandler) HandleBadHttpResponse(fromURL string, code int) {
-	log.Errorf("GET %s yielded bad HTTP response: %v (Code was %d)", fromURL, http.StatusText(code), code)
+	log.Errorf("GET %s, error %d: %v", fromURL, code, http.StatusText(code))
 	os.Exit(1)
 }
 

--- a/pkg/fetching/helpers.go
+++ b/pkg/fetching/helpers.go
@@ -43,7 +43,7 @@ func GetProxyLoggingFunc() func(req *http.Request) (*url.URL, error) {
 			if proxyURL == nil {
 				log.Infof("GET %v (direct).", req.URL)
 			} else {
-				log.Infof("GET %v (with proxy: %v).", req.URL, proxyURL)
+				log.Infof("GET %v (proxy: %v).", req.URL, proxyURL)
 			}
 		}
 		return proxyURL, err


### PR DESCRIPTION
Reduces unnecessary log size even further. Log messages are still well readable.