### PR TITLE
Display better error on missing resources

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -57,6 +57,9 @@ func main() {
 func initializeEnvironment() (*flags.LauncherFlags, error) {
 	registerSignalOverrides()
 
+	if (resources.LauncherConfig == nil) {
+		panic("LauncherConfig was not found / compiled into the binary.")
+	}
 	launcherFlags, argumentError, flagError, pathError, evalError, placesError := parseEnvironment()
 	launcherFlags.SetNextLogIndex(logging.Initialize(places.GetAppLogFolderPath(), resources.LauncherConfig.ProductName,
 		launcherFlags.LogIndexCounter, launcherFlags.LogInstanceCounter))


### PR DESCRIPTION
Instead of a panic because of a nil access, display the reason for the problem. While this would already fail if one uses our make file (go generate fails), one can still manually compile the launcher. As a developer I am currently doing this. So I think it does not hurt to add a little more friendly error message there.