### PR TITLE
do not crash when developer did not read the docs

### DIFF
--- a/pkg/launcher/timestamps/timestamps.go
+++ b/pkg/launcher/timestamps/timestamps.go
@@ -107,12 +107,16 @@ func checkTimestamp(oldTimestampAsString, newTimestampAsString string) {
 	} else {
 		oldTimestamp, err := time.Parse(timeFormat, oldTimestampAsString)
 		if err != nil {
-			panic(fmt.Sprintf("Could not parse old timestamp \"%s\": %v", oldTimestampAsString, err))
+			log.Warnf("Could not parse old timestamp \"%s\": %v", oldTimestampAsString, err)
+			log.Warnf("Running without verifying that no downgrade attack is occurring.")
+			return
 		}
 
 		newTimestamp, err := time.Parse(timeFormat, newTimestampAsString)
 		if err != nil {
-			panic(fmt.Sprintf("Could not parse new timestamp \"%s\": %v", newTimestampAsString, err))
+			log.Warnf("Could not parse new timestamp \"%s\": %v", newTimestampAsString, err)
+			log.Warnf("Running without verifying that no downgrade attack is occurring.")
+			return
 		}
 
 		if newTimestamp.Before(oldTimestamp) {


### PR DESCRIPTION
When timestamp replacement is not configured correctly, assume the mechanism is not wanted instead of failing.