### PR TITLE
Bug missing http2 conformity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 * trivrost will log the progress of downloads if the connection was interrupted for any reason.
 ### Fixes
 * `hasher` will no longer create a directory if a non-existing one is passed as an argument.
+* trivrost will no longer attempt to repeat range requests to a host after it has failed to conformly respond while displaying the confusing message `Taking longer than usual: HTTP Status 200` and will now fail immediately in such cases instead.
+* trivrost will no longer fail to comply with HTTP 2 strictly using lower-case HTTP Header names. This had been caused by methods of `http.Header` still being oriented around HTTP 1 canonical header names due to Go's backwards compatibility promise.
 
 ## 1.4.4 (2020-01-17)
 ### Changes

--- a/cmd/validator/metrics.go
+++ b/cmd/validator/metrics.go
@@ -31,7 +31,7 @@ func registerMetrics() {
 
 func (s metrics) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if req.Method != "GET" {
-		w.Header().Add("Allow", "GET")
+		w.Header()["allow"] = []string{"GET"}
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}

--- a/cmd/validator/service.go
+++ b/cmd/validator/service.go
@@ -17,7 +17,7 @@ type service struct {
 
 func (s service) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if req.Method != "GET" {
-		w.Header().Add("Allow", "GET")
+		w.Header()["allow"] = []string{"GET"}
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}

--- a/pkg/fetching/download.go
+++ b/pkg/fetching/download.go
@@ -184,9 +184,9 @@ func (dl *Download) processResponse() {
 }
 
 func (dl *Download) acceptFirstResponseHeader(header http.Header) {
-	contentLength, err := strconv.ParseInt(header.Get("Content-Length"), 10, 64)
+	contentLength, err := strconv.ParseInt(NewLowercaseHeaders(header).Get("content-length"), 10, 64)
 	if err != nil {
-		log.Printf("Assuming remote file won't change: Could not get Content-Length header from \"%s\": %v.", dl.url, err)
+		log.Printf("Assuming remote file won't change: Could not get content-length header from \"%s\": %v.", dl.url, err)
 		dl.lastByteIndex = -1
 	} else {
 		dl.lastByteIndex = contentLength - 1
@@ -284,5 +284,5 @@ func intMin(a, b int) int {
 }
 
 func isRangeRequest(req *http.Request) bool {
-	return strings.HasPrefix(req.Header.Get("Range"), "bytes=")
+	return strings.HasPrefix(NewLowercaseHeaders(req.Header).Get("range"), "bytes=")
 }

--- a/pkg/fetching/download.go
+++ b/pkg/fetching/download.go
@@ -41,11 +41,15 @@ func (wc *writeCounter) Write(p []byte) (int, error) {
 	return delta, nil
 }
 
-// Download wraps the retrieval of a resource at a URL using HTTP GET requests and exposes
-// the received data through its implementation of the io.Reader interface.
+// Download wraps the retrieval of a resource at a URL using HTTP GET requests and
+// exposes the received data through its implementation of the io.Reader interface.
+//
 // The Read() method will only return a non-nil error other than io.EOF when the
-// Content-Length of the requested resource changes during Download's attempts
-// to retrieve it. See Download.handler for Download's behavior in other error scenarios.
+// Content-Length of the requested resource changes during Download's attempts to
+// retrieve it or the remote signals that it cannot serve a range-request made in
+// an attempt to resume if the first GET was interrupted.
+//
+// See Download.handler for Download's behavior in other error scenarios.
 type Download struct {
 	url string // The URL of the resource to download.
 

--- a/pkg/fetching/downloader_test.go
+++ b/pkg/fetching/downloader_test.go
@@ -138,7 +138,7 @@ func CreateDummyEnvironment(t *testing.T, dataLength, failEvery int) *DummyEnvir
 			response.Header["content-range"] = []string{fmt.Sprintf("bytes %d-%d/%d", rangeStart, rangeEnd, dataLength)}
 		}
 		if !de.OmitContentLength {
-			response.Header["content-range"] = []string{fmt.Sprintf("%d", rangeEnd-rangeStart+1)}
+			response.Header["content-length"] = []string{fmt.Sprintf("%d", rangeEnd-rangeStart+1)}
 		}
 		response.Header["etag"] = []string{hex.EncodeToString(de.Data)}
 		response.Body = &RiggedReader{Reader: bytes.NewReader(de.Data[rangeStart : rangeEnd+1]), failEvery: failEvery, ctx: req.Context()}

--- a/pkg/fetching/downloader_test.go
+++ b/pkg/fetching/downloader_test.go
@@ -127,7 +127,7 @@ func CreateDummyEnvironment(t *testing.T, dataLength, failEvery int) *DummyEnvir
 	de.DoForClientFunc = func(client *http.Client, req *http.Request) (response *http.Response, err error) {
 		response = &http.Response{StatusCode: 200, Header: make(http.Header)}
 		var rangeStart, rangeEnd int64 = 0, int64(dataLength - 1)
-		requestedRange := req.Header.Get("Range")
+		requestedRange := NewLowercaseHeaders(req.Header).Get("range")
 		if requestedRange != "" {
 			rangeStart, rangeEnd, err = ParseRange(requestedRange, rangeEnd)
 			if err != nil {
@@ -135,12 +135,12 @@ func CreateDummyEnvironment(t *testing.T, dataLength, failEvery int) *DummyEnvir
 				return response, nil
 			}
 			response.StatusCode = http.StatusPartialContent
-			response.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rangeStart, rangeEnd, dataLength))
+			response.Header["content-range"] = []string{fmt.Sprintf("bytes %d-%d/%d", rangeStart, rangeEnd, dataLength)}
 		}
 		if !de.OmitContentLength {
-			response.Header.Set("Content-Length", fmt.Sprintf("%d", rangeEnd-rangeStart+1))
+			response.Header["content-range"] = []string{fmt.Sprintf("%d", rangeEnd-rangeStart+1)}
 		}
-		response.Header.Set("ETag", hex.EncodeToString(de.Data))
+		response.Header["etag"] = []string{hex.EncodeToString(de.Data)}
 		response.Body = &RiggedReader{Reader: bytes.NewReader(de.Data[rangeStart : rangeEnd+1]), failEvery: failEvery, ctx: req.Context()}
 		return response, nil
 	}

--- a/pkg/fetching/helpers.go
+++ b/pkg/fetching/helpers.go
@@ -63,9 +63,9 @@ func newRequestWithCancel(ctx context.Context, fromUrl string) (*http.Request, c
 func newRangeRequestWithCancel(ctx context.Context, fromUrl string, firstByte int64, lastByte int64) (*http.Request, context.CancelFunc) {
 	req, cancelFunc := newRequestWithCancel(ctx, fromUrl)
 	if lastByte >= 0 {
-		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", firstByte, lastByte))
+		req.Header["range"] = []string{fmt.Sprintf("bytes=%d-%d", firstByte, lastByte)}
 	} else {
-		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", firstByte))
+		req.Header["range"] = []string{fmt.Sprintf("bytes=%d-", firstByte)}
 	}
 	return req, cancelFunc
 }

--- a/pkg/fetching/lowercase_headers.go
+++ b/pkg/fetching/lowercase_headers.go
@@ -1,0 +1,46 @@
+package fetching
+
+import (
+	"net/http"
+	"strings"
+)
+
+// LowercaseHeaders models http.Header with each header name being lower-case.
+type LowercaseHeaders map[string][]string
+
+// NewLowercaseHeaders returns a map of headers for the given http.Header with all
+// header names in lower-case. Header names which overlap after becoming lower-case
+// have their values merged into one header in an unspecified order.
+func NewLowercaseHeaders(headers http.Header) LowercaseHeaders {
+	newHeaders := make(LowercaseHeaders)
+	for oldKey, oldValues := range headers {
+		newKey := strings.ToLower(oldKey)
+		if newValues, ok := newHeaders[newKey]; ok {
+			newHeaders[newKey] = append(newValues, oldValues...)
+		} else {
+			newValues := make([]string, 0, 0)
+			newHeaders[newKey] = append(newValues, oldValues...)
+		}
+	}
+	return newHeaders
+}
+
+// Get is analogous to http.Header.Get()
+func (h LowercaseHeaders) Get(header string) string {
+	header = strings.ToLower(header)
+	if values, ok := h[header]; ok {
+		if len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}
+
+// Values is analogous to http.Header.Values()
+func (h LowercaseHeaders) Values(header string) []string {
+	header = strings.ToLower(header)
+	if values, ok := h[header]; ok {
+		return values
+	}
+	return nil
+}

--- a/pkg/fetching/lowercase_headers_test.go
+++ b/pkg/fetching/lowercase_headers_test.go
@@ -1,0 +1,74 @@
+package fetching
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestNewLowercaseHeaders(t *testing.T) {
+	tests := []struct {
+		headers         http.Header
+		expectedHeaders LowercaseHeaders
+	}{
+		{nil, LowercaseHeaders{}},
+		{http.Header{}, LowercaseHeaders{}},
+		{http.Header{"content-type": {"foo"}}, LowercaseHeaders{"content-type": {"foo"}}},
+		{http.Header{"Content-Type": {"foo"}}, LowercaseHeaders{"content-type": {"foo"}}},
+		{http.Header{"Content-Type": {"foo"}, "Content-Length": {"3"}}, LowercaseHeaders{"content-type": {"foo"}, "content-length": {"3"}}},
+	}
+	for i, test := range tests {
+		lowerCaseHeaders := NewLowercaseHeaders(test.headers)
+		if !reflect.DeepEqual(lowerCaseHeaders, test.expectedHeaders) {
+			t.Errorf("Test #%d: lowerCaseHeaders = %v. Expected %v.", i+1, lowerCaseHeaders, test.expectedHeaders)
+		}
+	}
+}
+
+func TestLowercaseHeadersGet(t *testing.T) {
+	headers := NewLowercaseHeaders(http.Header{
+		"Content-Type":   {"foo"},
+		"Content-Length": {"3"},
+	})
+	if headers.Get("Content-Type") != "foo" {
+		t.Errorf(`headers.Get("Content-Type") != "foo"`)
+	}
+	if headers.Get("Content-Length") != "3" {
+		t.Errorf(`headers.Get("Content-Length") != "3"`)
+	}
+	if headers.Get("content-type") != "foo" {
+		t.Errorf(`headers.Get("content-type") != "foo"`)
+	}
+	if headers.Get("content-length") != "3" {
+		t.Errorf(`headers.Get("content-length") != "3"`)
+	}
+}
+
+func TestLowercaseValues(t *testing.T) {
+	headers := NewLowercaseHeaders(http.Header{
+		"Content-Type":   {"foo"},
+		"Content-Length": {"3"},
+		"content-type":   {"bar"},
+		"content-length": {"4"},
+	})
+	tests := []struct {
+		headerName     string
+		expectedValues map[string]int
+	}{
+		{"cOnTeNt-TyPe", map[string]int{"foo": 1, "bar": 1}},
+		{"cOnTeNt-LeNgTh", map[string]int{"3": 1, "4": 1}},
+	}
+	for _, test := range tests {
+		for _, value := range headers.Values(test.headerName) {
+			_, ok := test.expectedValues[value]
+			if !ok {
+				t.Errorf("unexpected or duplicate value '%s' for header name '%s'", value, test.headerName)
+			} else {
+				delete(test.expectedValues, value)
+			}
+		}
+		if len(test.expectedValues) > 0 {
+			t.Errorf("missing values for header name '%s': %v", test.headerName, test.expectedValues)
+		}
+	}
+}


### PR DESCRIPTION
This fixes 2 issues:
1. trivrost failing to comply with HTTP 2 strictly using lower-case HTTP Headers due to use of a Go standard library feature which has not been able to be adapted to HTTP 2 requirements due to Go's backwards compatibility promise.
2. trivrost futilely attempting to sweet-talk a non-Range-request-compliant remote into complying while displaying confusing message "Taking longer than usual: HTTP Status 200".