### PR TITLE
Update timeserver signing hash to SHA256

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 1.4.6 (2021-01-25)
 ### Fixes
-* Windows binary signing: Update timestamp config to avoid SHA-1 ciphers.
+* Windows binary signing: Use RFC-3161 timestamp server with sha 256 config. SHA-1 ciphers are considered deprecated. Nothing should change for the enduser.
 
 ## 1.4.5 (2021-01-04)
 ### Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release-Changelog
 
+## 1.4.6 (2021-01-25)
+### Fixes
+* Windows binary signing: Update timestamp config to avoid SHA-1 ciphers.
+
 ## 1.4.5 (2021-01-04)
 ### Fixes
 * Switch timestamp server for signing from Verisign to Globalsign.

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ifndef VERSIONOK
 endif
 $(info GIT description: '${GITDESC}' (latest master: '${LAUNCHER_VERSION}'), GIT branch '${GITBRANCH}', GIT hash '${GITHASH}')
 
-TIMESTAMP_SERVER = 'http://timestamp.globalsign.com/scripts/timstamp.dll'
+TIMESTAMP_SERVER = 'http://rfc3161timestamp.globalsign.com/advanced'
 
 #
 # Detect OS

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ ifndef CERT_KEY
 endif
 	$(info Signing windows release files...)
 	echo "$${CERT_FILE}" | base64 -d > ~tmp_launcher_cert
-	@signtool sign /debug /a /v /d "${LAUNCHER_BRANDING_NAME}" /f ~tmp_launcher_cert /p "${CERT_KEY}" /t ${TIMESTAMP_SERVER} /fd SHA512 "${UPDATE_FILES_DIR}/${OS}/${LAUNCHER_PROGRAM_NAME}.exe"
+	@signtool sign /debug /a /v /d "${LAUNCHER_BRANDING_NAME}" /f ~tmp_launcher_cert /p "${CERT_KEY}" /tr ${TIMESTAMP_SERVER} /td SHA256 /fd SHA512 "${UPDATE_FILES_DIR}/${OS}/${LAUNCHER_PROGRAM_NAME}.exe"
 	rm ~tmp_launcher_cert
 endif
 
@@ -166,8 +166,8 @@ ifneq (${OS},windows)
 else
 	$(info Signing windows release files...)
 	echo "$${CERT_FILE}" | base64 -d > ~tmp_launcher_cert
-	@signtool sign /debug /a /v /d "${LAUNCHER_BRANDING_NAME}" /f ~tmp_launcher_cert /p "${CERT_KEY}" /t ${TIMESTAMP_SERVER} /fd SHA512 "${RELEASE_FILES_DIR}/${OS}/${LAUNCHER_PROGRAM_NAME}_386.msi"
-	@signtool sign /debug /a /v /d "${LAUNCHER_BRANDING_NAME}" /f ~tmp_launcher_cert /p "${CERT_KEY}" /t ${TIMESTAMP_SERVER} /fd SHA512 "${RELEASE_FILES_DIR}/${OS}/${LAUNCHER_PROGRAM_NAME}_amd64.msi"
+	@signtool sign /debug /a /v /d "${LAUNCHER_BRANDING_NAME}" /f ~tmp_launcher_cert /p "${CERT_KEY}" /tr ${TIMESTAMP_SERVER} /td SHA256 /fd SHA512 "${RELEASE_FILES_DIR}/${OS}/${LAUNCHER_PROGRAM_NAME}_386.msi"
+	@signtool sign /debug /a /v /d "${LAUNCHER_BRANDING_NAME}" /f ~tmp_launcher_cert /p "${CERT_KEY}" /tr ${TIMESTAMP_SERVER} /td SHA256 /fd SHA512 "${RELEASE_FILES_DIR}/${OS}/${LAUNCHER_PROGRAM_NAME}_amd64.msi"
 	rm ~tmp_launcher_cert
 endif
 


### PR DESCRIPTION
Globalsign is disabling SHA-1 ciphers.

This will be all thrown away once we switch to mage, but for now, this is a quick fix.