### PR TITLE
Add newer Ubuntu, Mac and Golang versions to testmatrix

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,39 +5,20 @@ on:
 
 jobs:
   push:
-    strategy:
-      matrix:
-        go-version: [1.13.x]
-        platform: [ubuntu-18.04]
-    runs-on: ${{ matrix.platform }}
-    env:
-      GO111MODULE: "on"
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Install Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.16
       - name: Install libgtk-3-dev
-        if: matrix.platform == 'ubuntu-18.04'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y libgtk-3-dev
-      - name: Install goversioninfo
-        shell: bash
-        run: |
-          export GOPATH="${HOME}/go"
-          mkdir -p ${GOPATH}/bin
-          mkdir -p ${GOPATH}/pkg
-          mkdir -p ${GOPATH}/src
-          go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo@63e6d1acd3dd857ec6b8c54fbf52e10ce24a8786
+        run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
-      - name: Test and build
+      - name: Build
         shell: bash
         run: |
-          export GOPATH="${HOME}/go"
-          export PATH="${GOPATH}/bin:${PATH}"
           make test
           make copy-test-files
           make

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,6 @@ jobs:
         go-version: [ '1.13', '1.16' ]
         platform: [ ubuntu-18.04, ubuntu-20.04, macOS-10.15, windows-2019 ]
     runs-on: ${{ matrix.platform }}
-#    env:
-#      GOPATH: "${HOME}/go"
-#      PATH: "${PATH}:${GOPATH}/bin"
 
     steps:
       - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,12 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x]
-        platform: [ubuntu-18.04, macOS-10.15, windows-2019]
+        go-version: [ '1.13', '1.16' ]
+        platform: [ ubuntu-18.04, ubuntu-20.04, macOS-10.15, windows-2019 ]
     runs-on: ${{ matrix.platform }}
     env:
-      GO111MODULE: "on"
+      GOPATH: "${HOME}/go"
+      PATH: "${PATH}:${GOPATH}/bin"
 
     steps:
       - name: Install Go
@@ -20,32 +21,23 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install libgtk-3-dev
-        if: matrix.platform == 'ubuntu-18.04'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y libgtk-3-dev
+        if: startsWith(matrix.os, 'ubuntu')
+        run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev
       - name: Install UPX (Linux)
-        if: matrix.platform == 'ubuntu-18.04'
-        run: sudo apt-get update && sudo apt-get install upx-ucl
+        if: startsWith(matrix.os, 'ubuntu')
+        run: sudo apt-get update -y && sudo apt-get install -y upx-ucl
       - name: Install UPX (Windows)
-        if: matrix.platform == 'windows-2019'
+        if: startsWith(matrix.os, 'windows')
         run: choco install upx -y
-      - name: Install goversioninfo
-        shell: bash
-        run: |
-          export GOPATH="${HOME}/go"
-          mkdir -p ${GOPATH}/bin
-          mkdir -p ${GOPATH}/pkg
-          mkdir -p ${GOPATH}/src
-          go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo@63e6d1acd3dd857ec6b8c54fbf52e10ce24a8786
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
-      - name: Test and build
+      - name: Build
         shell: bash
         run: |
-          export GOPATH="${HOME}/go"
-          export PATH="${GOPATH}/bin:${PATH}"
-          make test
           make copy-test-files
           make
           make tools
+      - name: Test
+        shell: bash
+        run: |
+          make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,13 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install libgtk-3-dev
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: startsWith(matrix.platform, 'ubuntu')
         run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev
       - name: Install UPX (Linux)
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: startsWith(matrix.platform, 'ubuntu')
         run: sudo apt-get update -y && sudo apt-get install -y upx-ucl
       - name: Install UPX (Windows)
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: startsWith(matrix.platform, 'windows')
         run: choco install upx -y
       - name: Checkout repository
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,4 @@ jobs:
           make tools
       - name: Test
         shell: bash
-        run: |
-          make test
+        run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
         go-version: [ '1.13', '1.16' ]
         platform: [ ubuntu-18.04, ubuntu-20.04, macOS-10.15, windows-2019 ]
     runs-on: ${{ matrix.platform }}
-    env:
-      GOPATH: "${HOME}/go"
-      PATH: "${PATH}:${GOPATH}/bin"
+#    env:
+#      GOPATH: "${HOME}/go"
+#      PATH: "${PATH}:${GOPATH}/bin"
 
     steps:
       - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,13 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install libgtk-3-dev
-        if: startsWith(matrix.os, 'ubuntu')
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev
       - name: Install UPX (Linux)
-        if: startsWith(matrix.os, 'ubuntu')
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: sudo apt-get update -y && sudo apt-get install -y upx-ucl
       - name: Install UPX (Windows)
-        if: startsWith(matrix.os, 'windows')
+        if: ${{ startsWith(matrix.os, 'windows') }}
         run: choco install upx -y
       - name: Checkout repository
         uses: actions/checkout@v2.3.4


### PR DESCRIPTION
Also, GO111MODULE should default to on since 1.13 anyways. And our makefile
installs goversioninfo itself. Also spearate tests form building.