### PR TITLE
Don't edit go.mod when getting goversioninfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ copy-test-files: ## Copy example resources into resource directory
 	cp examples/defaulticon.ico cmd/launcher/resources/icon.ico
 
 generate:        ## Run go generate
-	go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
+	go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.2.0
 	go generate -installsuffix _separate -ldflags '${LDFLAGS}' ${MODULE_PATH_LAUNCHER}
 
 clean:           ## Clean generated files


### PR DESCRIPTION
After much debate about how, the Go team implemented a way to install a Go program without causing changes to go.mod, so we should use it.
See **Installing an executable at a specific version** at https://blog.golang.org/go116-module-changes

This requires Go 1.16.