### PR TITLE
Fix installdown parsing launcherversion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## TBD (TBD)
 ### Features
 ### Fixes
+* `installdown`: No longer fail to parse version strings as 'launcherversion' that contain a suffix after the SemVer or no 'v' prefix. For examples these version strings no longer break: 'v1.2.0-rc0', '1.2.0'
 ### Changes
 
 ## v1.6.0 (2022-05-16)

--- a/cmd/installdown/main.go
+++ b/cmd/installdown/main.go
@@ -35,6 +35,8 @@ const archGo64 = "amd64"
 const archWin32 = "x86"
 const archGo32 = "386"
 
+var validVersionRegex = regexp.MustCompile(`v?([0-9]+\.[0-9]+\.[0-9]+).*`)
+
 type wxsConfig struct {
 	VendorName        string
 	ProductName       string
@@ -207,12 +209,10 @@ func configure() *wxsConfig {
 	if *arch == archGo64 {
 		*arch = archWin64
 	}
-	versionRegex := `v?([0-9]+\.[0-9]+\.[0-9]+).*`
-	pattern := regexp.MustCompile(versionRegex)
-	versionMatch := pattern.FindAllStringSubmatch(*launcherVersion, -1)
 
+	versionMatch := validVersionRegex.FindAllStringSubmatch(*launcherVersion, -1)
 	if versionMatch == nil {
-		fatalf("Parameter --%s must be a version in the format %s. Found: %s", launcherVersionFlag, versionRegex, *launcherVersion)
+		fatalf("Parameter --%s must be a version in the format %s. Found: %s", launcherVersionFlag, validVersionRegex.String(), *launcherVersion)
 	}
 	*launcherVersion = versionMatch[0][1]
 	fmt.Printf("Using version %s for MSI.\n", *launcherVersion)

--- a/cmd/installdown/main.go
+++ b/cmd/installdown/main.go
@@ -207,12 +207,16 @@ func configure() *wxsConfig {
 	if *arch == archGo64 {
 		*arch = archWin64
 	}
-	versionRegex := `v?[0-9]+\.[0-9]+\.[0-9]+`
-	doesMatch, _ := regexp.MatchString(versionRegex, *launcherVersion)
-	if !doesMatch {
-		fatalf("Parameter --%s must be a version in the format %s.", launcherVersionFlag, versionRegex)
+	versionRegex := `v?([0-9]+\.[0-9]+\.[0-9]+).*`
+	pattern := regexp.MustCompile(versionRegex)
+	versionMatch := pattern.FindAllStringSubmatch(*launcherVersion, -1)
+
+	if versionMatch == nil {
+		fatalf("Parameter --%s must be a version in the format %s. Found: %s", launcherVersionFlag, versionRegex, *launcherVersion)
 	}
-	*launcherVersion = (*launcherVersion)[1:]
+	*launcherVersion = versionMatch[0][1]
+	fmt.Printf("Using version %s for MSI.\n", *launcherVersion)
+
 	if *outDir == "" {
 		fatalf("Parameter --%s cannot be empty.", outDirFlag)
 	}


### PR DESCRIPTION
No longer fail to parse version strings as 'launcherversion' that contain a suffix after the SemVer or no 'v' prefix. For examples these version strings no longer break: 'v1.2.0-rc0', '1.2.0'.