### PR TITLE
Raise minimal golang version and always run pipeline jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,10 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ '1.16', '1.18' ]
+        go-version: [ '1.20', '1.17' ]
         platform: [ ubuntu-20.04, macOS-10.15, windows-2019 ]
     runs-on: ${{ matrix.platform }}
+    if: always()
 
     steps:
       - name: Install Go

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release-Changelog
 
+## TBD (TBD)
+### Changes
+* Raise minimum golang requirement to 1.17
+
 ## v1.7.0 (2023-05-23)
 ### Changes
 * No changes, just a re-tag of v1.7.0-rc0


### PR DESCRIPTION
Pipeline jobs were aborted when one crashed, now all checks always run. Also raise minimal go version to 1.17 since golang.org/x/net in the newest version requires this!