### PR TITLE
Fix invalid XML template for metainfo, causing MacOS to fail on start

### DIFF
--- a/cmd/metawriter/main.go
+++ b/cmd/metawriter/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"html"
 	"io"
 	"io/ioutil"
 	"os"
@@ -39,16 +40,16 @@ func writeMetaFiles() {
 }
 
 func replacePlaceholders(text string) string {
-	text = strings.Replace(text, "${LAUNCHER_BINARY}", os.Getenv("LAUNCHER_BINARY"), -1)
-	text = strings.Replace(text, "${LAUNCHER_BINARY_EXT}", os.Getenv("LAUNCHER_BINARY_EXT"), -1)
-	text = strings.Replace(text, "${LAUNCHER_VENDOR_NAME}", launcherConfig.VendorName, -1)
-	text = strings.Replace(text, "${LAUNCHER_BRANDING_NAME}", launcherConfig.BrandingName, -1)
-	text = strings.Replace(text, "${LAUNCHER_BRANDING_NAME_SHORT}", launcherConfig.BrandingNameShort, -1)
-	text = strings.Replace(text, "${LAUNCHER_REVERSE_DNS_PRODUCT_ID}", launcherConfig.ReverseDnsProductId, -1)
-	text = strings.Replace(text, "${LAUNCHER_VERSION_MAJOR}", strconv.Itoa(launcherConfig.ProductVersion.Major), -1)
-	text = strings.Replace(text, "${LAUNCHER_VERSION_MINOR}", strconv.Itoa(launcherConfig.ProductVersion.Minor), -1)
-	text = strings.Replace(text, "${LAUNCHER_VERSION_PATCH}", strconv.Itoa(launcherConfig.ProductVersion.Patch), -1)
-	text = strings.Replace(text, "${LAUNCHER_VERSION_BUILD}", strconv.Itoa(launcherConfig.ProductVersion.Build), -1)
+	text = strings.Replace(text, "${LAUNCHER_BINARY}", html.EscapeString(os.Getenv("LAUNCHER_BINARY"))), -1)
+	text = strings.Replace(text, "${LAUNCHER_BINARY_EXT}", html.EscapeString(os.Getenv("LAUNCHER_BINARY_EXT")), -1)
+	text = strings.Replace(text, "${LAUNCHER_VENDOR_NAME}", html.EscapeString(launcherConfig.VendorName), -1)
+	text = strings.Replace(text, "${LAUNCHER_BRANDING_NAME}", html.EscapeString(launcherConfig.BrandingName), -1)
+	text = strings.Replace(text, "${LAUNCHER_BRANDING_NAME_SHORT}", html.EscapeString(launcherConfig.BrandingNameShort), -1)
+	text = strings.Replace(text, "${LAUNCHER_REVERSE_DNS_PRODUCT_ID}", html.EscapeString(launcherConfig.ReverseDnsProductId), -1)
+	text = strings.Replace(text, "${LAUNCHER_VERSION_MAJOR}", strconv.Itoa(html.EscapeString(launcherConfig.ProductVersion.Major)), -1)
+	text = strings.Replace(text, "${LAUNCHER_VERSION_MINOR}", strconv.Itoa(html.EscapeString(launcherConfig.ProductVersion.Minor)), -1)
+	text = strings.Replace(text, "${LAUNCHER_VERSION_PATCH}", strconv.Itoa(html.EscapeString(launcherConfig.ProductVersion.Patch)), -1)
+	text = strings.Replace(text, "${LAUNCHER_VERSION_BUILD}", strconv.Itoa(html.EscapeString(launcherConfig.ProductVersion.Build)), -1)
 	text = strings.Replace(text, "${LAUNCHER_VERSION_SEMANTIC}", versionSemantic, -1)
 	text = strings.Replace(text, "${LAUNCHER_VERSION_FULL}", versionFull, -1)
 	return text

--- a/cmd/metawriter/replace_test.go
+++ b/cmd/metawriter/replace_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// TestReplacePlaceholders checks if the placeholders are replaced and escaped correctly
+func TestReplacePlaceholders(t *testing.T) {
+	os.Setenv("LAUNCHER_BINARY", "launcher&binary")
+	launcherConfig = &config.LauncherConfig{
+		VendorName:          "Example<Vendor>",
+		BrandingName:        "Brand\"Name",
+		BrandingNameShort:   "Short'Name",
+		ReverseDnsProductId: "com.example>product",
+		ProductVersion: config.ProductVersionStruct{
+			Major: 1,
+			Minor: 2,
+			Patch: 3,
+			Build: 4,
+		},
+	}
+
+	versionSemantic = "1.2.3"
+	versionFull = "1.2.3.4"
+
+	// Simulating a template with all placeholders
+	template := `${LAUNCHER_BINARY} ${LAUNCHER_BINARY_EXT} ${LAUNCHER_VENDOR_NAME} ${LAUNCHER_BRANDING_NAME} ${LAUNCHER_BRANDING_NAME_SHORT} ${LAUNCHER_REVERSE_DNS_PRODUCT_ID} ${LAUNCHER_VERSION_MAJOR} ${LAUNCHER_VERSION_MINOR} ${LAUNCHER_VERSION_PATCH} ${LAUNCHER_VERSION_BUILD} ${LAUNCHER_VERSION_SEMANTIC} ${LAUNCHER_VERSION_FULL}`
+
+	expected := `launcher&amp;binary ${LAUNCHER_BINARY_EXT} Example&lt;Vendor&gt; Brand&quot;Name Short&apos;Name com.example&gt;product 1 2 3 4 1.2.3 1.2.3.4`
+	result := replacePlaceholders(template)
+
+	if result != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, result)
+	}
+}


### PR DESCRIPTION
The metadata replacement happens also for versioninfo.json, which is used for the Windows metainfo, or?

Will &amp; and such then start appearing in the Windows metainfo? :S