### PR TITLE
Add validation for bundle file paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 ### Features
 * Add optional environment variable `EXTRA_CGO_LDFLAGS` to Makefile, which can be used to add `CGO_LDFLAGS` to the build process under darwin.
 
+### Fixes
+* Reject invalid file paths in bundle info files before updating local bundles.
+
 ## v1.8.2 (2023-12-21)
 ### Features
 * MSI property `ADDROAMINGARGUMENT` can be provided with value `true` to have installed shortcuts provided with the `--roaming` argument.

--- a/pkg/launcher/config/bundleinfo.go
+++ b/pkg/launcher/config/bundleinfo.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -141,7 +142,27 @@ func ReadInfoFromByteSlice(data []byte) *BundleInfo {
 	if err != nil {
 		panic(err)
 	}
+	validateBundleInfoPaths(info.BundleFiles)
 	return &info
+}
+
+func validateBundleInfoPaths(bundleFiles FileInfoMap) {
+	for filePath := range bundleFiles {
+		if filePath == "" {
+			panic("Bundle info contains an empty file path")
+		}
+		if strings.HasPrefix(filePath, "/") {
+			panic(fmt.Sprintf("Bundle info file path %q must not be absolute", filePath))
+		}
+
+		cleanPath := path.Clean(filePath)
+		if cleanPath == "." || cleanPath == ".." || strings.HasPrefix(cleanPath, "../") {
+			panic(fmt.Sprintf("Bundle info file path %q escapes the bundle directory", filePath))
+		}
+		if cleanPath != filePath {
+			panic(fmt.Sprintf("Bundle info file path %q must be clean and normalized; use %q instead", filePath, cleanPath))
+		}
+	}
 }
 
 func WriteInfo(info *BundleInfo, filePath string) {

--- a/pkg/launcher/config/bundleinfo_test.go
+++ b/pkg/launcher/config/bundleinfo_test.go
@@ -1,0 +1,63 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/setlog/trivrost/pkg/launcher/config"
+)
+
+func TestReadBundleInfoAcceptsCleanRelativePaths(t *testing.T) {
+	reader := strings.NewReader(`{
+		"Timestamp": "2019-02-07 14:53:17",
+		"UniqueBundleName": "bundle",
+		"BundleFiles": {
+			"app/bin/run": { "SHA256": "abc", "Size": 1 },
+			"top.txt": { "SHA256": "def", "Size": 2 }
+		}
+	}`)
+
+	info := config.ReadInfoFromReader(reader)
+	hashes := info.GetFileHashes()
+
+	if _, ok := hashes["app/bin/run"]; !ok {
+		t.Fatalf("expected nested clean path to be kept")
+	}
+	if _, ok := hashes["top.txt"]; !ok {
+		t.Fatalf("expected top-level clean path to be kept")
+	}
+}
+
+func TestReadBundleInfoRejectsUnsafePaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+	}{
+		{name: "empty", filePath: ""},
+		{name: "absolute", filePath: "/etc/passwd"},
+		{name: "parentTraversal", filePath: "../outside"},
+		{name: "embeddedTraversal", filePath: "app/../outside"},
+		{name: "dotPrefix", filePath: "./app"},
+		{name: "doubleSlash", filePath: "app//file"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader := strings.NewReader(`{
+				"Timestamp": "2019-02-07 14:53:17",
+				"UniqueBundleName": "bundle",
+				"BundleFiles": {
+					"` + test.filePath + `": { "SHA256": "abc", "Size": 1 }
+				}
+			}`)
+
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("expected panic for unsafe bundle file path %q", test.filePath)
+				}
+			}()
+
+			config.ReadInfoFromReader(reader)
+		})
+	}
+}


### PR DESCRIPTION
Bundles technically allowed paths outside the bundle or absolute paths. This sanitizes the paths.